### PR TITLE
Centralize determination of default config path

### DIFF
--- a/src/inworldz/util/estate.py
+++ b/src/inworldz/util/estate.py
@@ -102,9 +102,8 @@ if __name__ == "__main__":
     from inworldz.util.user import LookupUserIdByName
     from inworldz.maestro.version import product_name
     appdata = getCurrentUsersAppDataPath()
-    propfile = os.path.join(appdata, product_name(), "maestro.config")
     props = DefaultProperties.instance()
-    props.loadConfiguration(propfile)
+    props.loadConfiguration()
     
     userid = LookupUserIdByName("Mike", "Chase")
     print userid

--- a/src/inworldz/util/properties.py
+++ b/src/inworldz/util/properties.py
@@ -44,10 +44,14 @@ class DefaultProperties():
     @property
     def hostName(self):
         return self.hostingResource.hostName
+    
+    @property
+    def defaultConfigFilePath(self):
+        return os.path.join(self.appdata, product_name(), "maestro.config")
 
     def loadConfiguration(self, filePath=None):
         if (filePath == None):
-            filePath = os.path.join(self.appdata, product_name(), "maestro.config")
+            filePath = self.defaultConfigFilePath
         if (os.path.exists(filePath)):
             self.configParser.read(filePath)
 

--- a/src/inworldz/util/user.py
+++ b/src/inworldz/util/user.py
@@ -42,9 +42,8 @@ if __name__ == "__main__":
     from inworldz.util.filesystem import getCurrentUsersAppDataPath
     from inworldz.maestro.version import product_name
     appdata = getCurrentUsersAppDataPath()
-    propfile = os.path.join(appdata, product_name(), "maestro.config")
     props = DefaultProperties.instance()
-    props.loadConfiguration(propfile)
+    props.loadConfiguration()
     
     userid = LookupUserIdByName("Mike", "Chase")
     print userid

--- a/src/server.py
+++ b/src/server.py
@@ -52,9 +52,9 @@ def main(argv=None):
         parser.add_option("-v", "--verbose", dest="verbose", action="count", help="set verbosity level [default: %default]")
 
         # set defaults
+        props = DefaultProperties.instance()
         appdata = getCurrentUsersAppDataPath()
-        propfile = os.path.join(appdata, product_name(), "maestro.config")
-        parser.set_defaults(address="0.0.0.0", port=DEFAULT_PORT, verbose=1, propfile=propfile)
+        parser.set_defaults(address="0.0.0.0", port=DEFAULT_PORT, verbose=1, propfile=props.defaultConfigFilePath)
 
         # process options
         (opts, args) = parser.parse_args(argv)
@@ -74,9 +74,8 @@ def main(argv=None):
             print("propfile = %s" % opts.propfile)
 
         # Load Default Properties
-        props = DefaultProperties.instance()
         if (opts.propfile != None):
-            props.loadConfiguration(propfile)
+            props.loadConfiguration(opts.propfile)
 
         #set encryption key
         CredentialCrypt.SECRET = props.getValue("credential_crypt_secret")

--- a/src/service.py
+++ b/src/service.py
@@ -57,11 +57,11 @@ class MaestroService(win32serviceutil.ServiceFramework):
 
     def starting(self):
         try:
+            self.props = DefaultProperties.instance()
             self.appdata = getCurrentUsersAppDataPath()
-            self.propfile = os.path.join(self.appdata, product_name(), "maestro.config") 
+            self.propfile = self.props.defaultConfigFilePath
             self.address = "0.0.0.0"
             self.port = 12089
-            self.props = DefaultProperties.instance()
             self.props.loadConfiguration(self.propfile)
             self.server = MaestroServer(AUTH_WINDOWS, self.address, self.port, self.propfile)
             self.thread = Thread(target = self.server.run, args = ())


### PR DESCRIPTION
Why scatter the logic everywhere when putting it in one place makes verifying correctness a lot easier.